### PR TITLE
Add parameter to return all stations from luqs function

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Returns an array containing all LUQS stations.
 
 Source: https://www.lanuv.nrw.de/luqs/messorte/messorte.php
 
+Optionally accepts an `options` object as first parameter:
+
+- `allStations: true` returns all active and inactive stations.
+
 ### luqs.station(kuerzel)
 Returns detailed information about a specific LUQS station
 

--- a/index.js
+++ b/index.js
@@ -17,9 +17,13 @@ const MAX_KUERZEL_LENGTH = 6
  *
  * @param {String} url
  */
-const query = (url) => {
+const query = (url, options = {}) => {
   return new Promise((resolve, reject) => {
-    request(url, function (error, response, body) {
+    request({
+      url,
+      method: options.method ? options.method : 'GET',
+      form: options.form ? options.form : undefined
+    }, function (error, response, body) {
       if (error) {
         reject(error)
       }
@@ -37,12 +41,23 @@ const query = (url) => {
 /**
  * Requests LUQS stations website and parse stations table.
  *
- * @param {*} options
+ * @param options.allStations return all stations if true
  * @returns Promise resolves with an array of all luqs stations
  */
 const luqs = (options = {}) => {
   return new Promise((resolve, reject) => {
-    query(messorteUrl)
+    let requestOptions
+    if (options.allStations === true) {
+      requestOptions = {
+        method: 'POST',
+        form: {
+          auswahl_plz: 'alle',
+          auswahl_status: 'alle',
+          auswahl_klassifizierung: 'alle'
+        }
+      }
+    }
+    query(messorteUrl, requestOptions)
       .then($ => {
         const stations = []
         const tableRows = $('#wrapper > table > tbody > tr')

--- a/test.js
+++ b/test.js
@@ -4,7 +4,13 @@ import luqs from '.'
 test('luqs()', async t => {
   const stations = await luqs()
   t.truthy(Array.isArray(stations))
-  t.is(stations.length, 165)
+  t.truthy(stations.length > 160)
+})
+
+test('luqs({ allStations: true })', async t => {
+  const stations = await luqs({ allStations: true })
+  t.truthy(Array.isArray(stations))
+  t.truthy(stations.length > 578)
 })
 
 test('luqs.station() should reject with TypeError', async t => {


### PR DESCRIPTION
This pull request adds a `allStations` key to the `luqs` function. Specifying this option returns all stations.